### PR TITLE
Fix incorrect usage of "SteamGridDB" strings.

### DIFF
--- a/SGDBMetadata/SGDBMetadata.cs
+++ b/SGDBMetadata/SGDBMetadata.cs
@@ -25,7 +25,7 @@ namespace SGDBMetadata
         };
 
         // Change to something more appropriate
-        public override string Name => "Steam Grid DB Metadata";
+        public override string Name => "SteamGridDB Metadata";
 
         public SGDBMetadata(IPlayniteAPI api) : base(api)
         {

--- a/SGDBMetadata/SGDBMetadataSettingsView.xaml
+++ b/SGDBMetadata/SGDBMetadataSettingsView.xaml
@@ -6,7 +6,7 @@
              mc:Ignorable="d"
              d:DesignHeight="400" d:DesignWidth="600">
     <StackPanel>
-        <TextBlock Text="SteamGrid DB API Key"/>
+        <TextBlock Text="SteamGridDB API Key"/>
         <TextBox Text="{Binding Option1}"/>
 
       <TextBlock Text="Cover Style:" Margin="15,10,20,0"/>


### PR DESCRIPTION
Changes "SteamGrid DB" and "Steam Grid DB" to "SteamGridDB".